### PR TITLE
add function to re-run the last run debug_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ lua require('dap-go').setup()
 
 ### Debugging individual tests
 
+
 To debug the closest method above the cursor use you can run:
 - `:lua require('dap-go').debug_test()` 
+
+Once a test was run, you can simply run it again from anywhere:
+- `:lua require('dap-go').debug_last_test()` 
 
 It is better to define a mapping to invoke this command. See the mapping section bellow.
 

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -1,6 +1,9 @@
 local query = require "vim.treesitter.query"
 
-local M = {}
+local M = {
+	last_testname = "",
+	last_testpath = "",
+}
 
 local tests_query = [[
 (function_declaration
@@ -260,9 +263,37 @@ end
 
 function M.debug_test()
   local testname = get_closest_test()
-  local msg = string.format("starting debug session '%s'...", testname)
+  local relativeFileDirname = vim.fn.fnamemodify(vim.fn.expand("%:.:h"), ":r")
+  local testpath = string.format("./%s", relativeFileDirname)
+
+  if testname == "" then
+    print("no test found")
+	return false
+  end
+
+  M.last_testname = testname
+  M.last_testpath = testpath
+
+  local msg = string.format("starting debug session '%s : %s'...", testpath, testname)
   print(msg)
-  debug_test(testname)
+  debug_test(testname, testpath)
+
+  return true
+end
+
+function M.debug_last_test()
+  local testname = M.last_testname
+  local testpath = M.last_testpath
+
+  if testname == "" then
+    print("no last run test found")
+    return false
+  end
+
+  local msg = string.format("starting debug session '%s : %s'...", testpath, testname)
+  print(msg)
+  debug_test(testname, testpath)
+  return true
 end
 
 return M

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -150,14 +150,14 @@ function M.setup()
   setup_go_configuration(dap)
 end
 
-local function debug_test(testname)
+local function debug_test(testname, testpath)
   local dap = load_module("dap")
   dap.run({
       type = "go",
       name = testname,
       request = "launch",
       mode = "test",
-      program = "./${relativeFileDirname}",
+      program = testpath,
       args = {"-test.run", testname},
   })
 end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -269,7 +269,7 @@ function M.debug_test()
   local testpath = string.format("./%s", relativeFileDirname)
 
   if testname == "" then
-    print("no test found")
+    vim.notify("no test found")
 	return false
   end
 
@@ -277,7 +277,7 @@ function M.debug_test()
   M.last_testpath = testpath
 
   local msg = string.format("starting debug session '%s : %s'...", testpath, testname)
-  print(msg)
+  vim.notify(msg)
   debug_test(testname, testpath)
 
   return true
@@ -288,12 +288,12 @@ function M.debug_last_test()
   local testpath = M.last_testpath
 
   if testname == "" then
-    print("no last run test found")
+    vim.notify("no last run test found")
     return false
   end
 
   local msg = string.format("starting debug session '%s : %s'...", testpath, testname)
-  print(msg)
+  vim.notify(msg)
   debug_test(testname, testpath)
   return true
 end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -175,7 +175,9 @@ local function get_closest_above_cursor(test_tree)
       end
     end
   end
-  if result.parent then
+  if result == nil then
+    return ""
+  elseif result.parent then
     return string.format("%s/%s", result.parent, result.name)
   else
     return result.name


### PR DESCRIPTION
Implements feature requested in https://github.com/leoluz/nvim-dap-go/issues/17

I also made debug_test return true/false so one can have one keymapping to do something like:

```
function()
	if require("dap-go").debug_test() ~= true then
		require("dap-go").debug_last_test()
	end
end,
```

Plus changed the prints to vim.notify() instead.