### PR TITLE
allow debugging of files with build tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ lua require('dap-go').setup {
     port = "${port}",
     -- additional args to pass to dlv
     args = {}
+    -- the build flags that are passed to delve.
+    -- defaults to empty string, but can be used to provide flags
+    -- such as "-tags=unit" to make sure the test suite is
+    -- compiled during debugging, for example.
+    -- passing build flags using args is ineffective, as those are
+    -- ignored by delve in dap mode.
+    build_flags = "",
   },
 }
 ```


### PR DESCRIPTION
This should solve #35 and #36.

It is a bit more invasive than I would have liked for a first PR here, but the configuration needs to be accessible for the debug_test local function. If you don't like having the config as an attribute to the module object, I can rewrite this to expose additional `debug_test_with_buildflags(buildflags)` functions instead, but I actually think it is cleaner this way.

Thanks for the plugin, btw :)