### PR TITLE
Add Debug Package (Arguments) configuration

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -95,6 +95,13 @@ local function setup_go_configuration(dap, configs)
     },
     {
       type = "go",
+      name = "Debug Package (Arguments)",
+      request = "launch",
+      program = "${fileDirname}",
+      args = get_arguments,
+    },
+    {
+      type = "go",
       name = "Attach",
       mode = "local",
       request = "attach",


### PR DESCRIPTION
Hello! Thank you for great plugin! 

This configuration will be useful for those whose application does not start without arguments and contains several files in the main package. In addition, it seems logical to have such a configuration. 

<img width="639" alt="image" src="https://user-images.githubusercontent.com/22278399/230744222-2b2ee40d-c4e5-4049-9387-5bdf04dab405.png">

I unfortunately can't add such a configuration via dap_configurations. Now I have to use vs-code launch.json to start my apps.

Thank you!