### PR TITLE
Add delve option to pass additional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ lua require('dap-go').setup {
     -- a string that defines the port to start delve debugger.
     -- default to string "${port}" which instructs nvim-dap
     -- to start the process in a random available port
-    port = "${port}"
+    port = "${port}",
+    -- additional args to pass to dlv
+    args = {}
   },
 }
 ```

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -78,6 +78,8 @@ The example bellow shows all the possible configurations:
         -- default to string "${port}" which instructs nvim-dap
         -- to start the process in a random available port
         port = "${port}"
+        -- additional args to pass to dlv
+        args = {}
       },
     }
 <

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -9,6 +9,7 @@ local default_config = {
   delve = {
     initialize_timeout_sec = 20,
     port = "${port}",
+    args = {},
   },
 }
 
@@ -59,12 +60,15 @@ local function get_arguments()
 end
 
 local function setup_delve_adapter(dap, config)
+  local args = { "dap", "-l", "127.0.0.1:" .. config.delve.port }
+  vim.list_extend(args, config.delve.args)
+
   dap.adapters.go = {
     type = "server",
     port = config.delve.port,
     executable = {
       command = "dlv",
-      args = { "dap", "-l", "127.0.0.1:" .. config.delve.port },
+      args = args,
     },
     options = {
       initialize_timeout_sec = config.delve.initialize_timeout_sec,


### PR DESCRIPTION
For example, I need to pass `--check-go-version=false` when using unreleased go version.