### PR TITLE
fix deprecation warnings for treesitter parse_query

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -197,7 +197,7 @@ local function get_closest_test()
 
   local test_tree = {}
 
-  local test_query = vim.treesitter.parse_query(ft, tests_query)
+  local test_query = vim.treesitter.query.parse_query(ft, tests_query)
   assert(test_query, "dap-go error: could not parse test query")
   for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
     local test_match = {}
@@ -214,7 +214,7 @@ local function get_closest_test()
     table.insert(test_tree, test_match)
   end
 
-  local subtest_query = vim.treesitter.parse_query(ft, subtests_query)
+  local subtest_query = vim.treesitter.query.parse_query(ft, subtests_query)
   assert(subtest_query, "dap-go error: could not parse test query")
   for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row) do
     local test_match = {}

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -197,7 +197,7 @@ local function get_closest_test()
 
   local test_tree = {}
 
-  local test_query = vim.treesitter.query.parse_query(ft, tests_query)
+  local test_query = vim.treesitter.query.parse(ft, tests_query)
   assert(test_query, "dap-go error: could not parse test query")
   for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
     local test_match = {}
@@ -214,7 +214,7 @@ local function get_closest_test()
     table.insert(test_tree, test_match)
   end
 
-  local subtest_query = vim.treesitter.query.parse_query(ft, subtests_query)
+  local subtest_query = vim.treesitter.query.parse(ft, subtests_query)
   assert(subtest_query, "dap-go error: could not parse test query")
   for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row) do
     local test_match = {}

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -204,7 +204,7 @@ local function get_closest_test()
     for id, node in pairs(match) do
       local capture = test_query.captures[id]
       if capture == "testname" then
-        local name = query.get_node_text(node, 0)
+        local name = vim.treesitter.get_node_text(node, 0)
         test_match.name = name
       end
       if capture == "parent" then
@@ -221,7 +221,7 @@ local function get_closest_test()
     for id, node in pairs(match) do
       local capture = subtest_query.captures[id]
       if capture == "testname" then
-        local name = query.get_node_text(node, 0)
+        local name = vim.treesitter.get_node_text(node, 0)
         test_match.name = string.gsub(string.gsub(name, " ", "_"), '"', "")
       end
       if capture == "parent" then


### PR DESCRIPTION
This PR fixes in the deprecation warnings due to the usage of `treesitter.parse_query` function, which will be removed in the next version of neovim (0.10).

![image](https://user-images.githubusercontent.com/3148319/236644130-903d06e4-0f57-4866-a6b3-376e04f38648.png)
