### PR TITLE
Allow configuration of dlv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ lua require('dap-go').setup {
   delve = {
     -- the path to the executable dlv which will be used for debugging.
     -- by default, this is the "dlv" executable on your PATH.
-    path_to_delve = "dlv",
+    path = "dlv",
     -- time to wait for delve to initialize the debug session.
     -- default to 20 seconds
     initialize_timeout_sec = 20,

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ lua require('dap-go').setup {
   },
   -- delve configurations
   delve = {
+    -- the path to the executable dlv which will be used for debugging.
+    -- by default, this is the "dlv" executable on your PATH.
+    path_to_delve = "dlv",
     -- time to wait for delve to initialize the debug session.
     -- default to 20 seconds
     initialize_timeout_sec = 20,

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -71,6 +71,9 @@ The example bellow shows all the possible configurations:
       },
       -- delve configurations
       delve = {
+        -- the path to the executable dlv which will be used for debugging.
+        -- by default, this is the "dlv" executable on your PATH.
+        path = "dlv",
         -- time to wait for delve to initialize the debug session.
         -- default to 20 seconds
         initialize_timeout_sec = 20,

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -7,6 +7,7 @@ local M = {
 
 local default_config = {
   delve = {
+    path_to_delve = "dlv",
     initialize_timeout_sec = 20,
     port = "${port}",
   },
@@ -63,7 +64,7 @@ local function setup_delve_adapter(dap, config)
     type = "server",
     port = config.delve.port,
     executable = {
-      command = "dlv",
+      command = config.delve.path_to_delve,
       args = { "dap", "-l", "127.0.0.1:" .. config.delve.port },
     },
     options = {

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -7,7 +7,7 @@ local M = {
 
 local default_config = {
   delve = {
-    path_to_delve = "dlv",
+    path = "dlv",
     initialize_timeout_sec = 20,
     port = "${port}",
   },
@@ -64,7 +64,7 @@ local function setup_delve_adapter(dap, config)
     type = "server",
     port = config.delve.port,
     executable = {
-      command = config.delve.path_to_delve,
+      command = config.delve.path,
       args = { "dap", "-l", "127.0.0.1:" .. config.delve.port },
     },
     options = {

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -68,7 +68,6 @@ local function setup_delve_adapter(dap, config)
     executable = {
       command = config.delve.path,
       args = args,
-      args = { "dap", "-l", "127.0.0.1:" .. config.delve.port },
     },
     options = {
       initialize_timeout_sec = config.delve.initialize_timeout_sec,


### PR DESCRIPTION
@leoluz, thank you so much for creating such a great DAP for Go. I use it every day at work.

I found that my installation was using a version of `dlv` I could not track down. I deleted every version from my `PATH` environment variable. It was stuck on a version `1.9` or so. It would be interesting to take you through what was going on there if you have any thoughts on what it could be.

Suffice it to say, I was unable to get the debugger working when I upgraded to Go 1.20 and needed to patch in my own path to the `dlv` executable. I figured I would submit the change I made upstream so that if others run into a similar problem, they can set the path to their `dlv` executable manually. This doesn't change the default behavior at all, just allows users to override the exectuable.