### PR TITLE
Input arguments synchronously

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -45,18 +45,13 @@ local function get_arguments()
   local co = coroutine.running()
   if co then
     return coroutine.create(function()
-      local args = {}
-      vim.ui.input({ prompt = "Args: " }, function(input)
-        args = vim.split(input or "", " ")
-      end)
+      local input = vim.fn.input("Args: ")
+      local args = vim.split(input or "", " ")
       coroutine.resume(co, args)
     end)
   else
-    local args = {}
-    vim.ui.input({ prompt = "Args: " }, function(input)
-      args = vim.split(input or "", " ")
-    end)
-    return args
+    local input = vim.fn.input("Args: ")
+    return vim.split(input or "", " ")
   end
 end
 


### PR DESCRIPTION
The default implementation of `vim.ui.input` is synchronously, but the document says it could be potentially asynchronous:

![image](https://github.com/leoluz/nvim-dap-go/assets/7448852/84c94885-9336-4949-9ab7-2e41478b0ead)

Lots of people uses [dressing.nvim](https://github.com/stevearc/dressing.nvim) to override the default `vim.ui.input` to have a nice UI, which implementation is asynchronously, then the `get_arguments` in `nvim-dap-go` will always empty.

And `vim.fn.input` is designed to synchronously, which we should use.
 
So this PR simply change from `vim.ui.input` to `vim.fn.input`.