### PR TITLE
feat: allow debugging a single nested test at any level

### DIFF
--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -1,0 +1,168 @@
+local M = {}
+
+local tests_query = [[
+(function_declaration
+  name: (identifier) @testname
+  parameters: (parameter_list
+    . (parameter_declaration
+      type: (pointer_type) @type) .)
+  (#match? @type "*testing.(T|M)")
+  (#match? @testname "^Test.+$")) @parent
+]]
+
+local subtests_query = [[
+(call_expression
+  function: (selector_expression
+    operand: (identifier)
+    field: (field_identifier) @run)
+  arguments: (argument_list
+    (interpreted_string_literal) @testname
+    (func_literal))
+  (#eq? @run "Run")) @parent
+]]
+
+local function format_subtest(testcase, test_tree)
+  local parent
+  if testcase.parent then
+    for _, curr in pairs(test_tree) do
+      if curr.name == testcase.parent then
+        parent = curr
+        break
+      end
+    end
+    return string.format("%s/%s", format_subtest(parent, test_tree), testcase.name)
+  else
+    return testcase.name
+  end
+end
+
+local function get_closest_above_cursor(test_tree)
+  local result
+  for _, curr in pairs(test_tree) do
+    if not result then
+      result = curr
+    else
+      local node_row1, _, _, _ = curr.node:range()
+      local result_row1, _, _, _ = result.node:range()
+      if node_row1 > result_row1 then
+        result = curr
+      end
+    end
+  end
+  if result then
+    return format_subtest(result, test_tree)
+  end
+  return nil
+end
+
+local function is_parent(dest, source)
+  if not (dest and source) then
+    return false
+  end
+  if dest == source then
+    return false
+  end
+
+  local current = source
+  while current ~= nil do
+    if current == dest then
+      return true
+    end
+
+    current = current:parent()
+  end
+
+  return false
+end
+
+local function get_closest_test()
+  local stop_row = vim.api.nvim_win_get_cursor(0)[1]
+  local ft = vim.api.nvim_buf_get_option(0, 'filetype')
+  assert(ft == 'go', 'can only find test in go files, not ' .. ft)
+  local parser = vim.treesitter.get_parser(0)
+  local root = (parser:parse()[1]):root()
+
+  local test_tree = {}
+
+  local test_query = vim.treesitter.query.parse(ft, tests_query)
+  assert(test_query, 'could not parse test query')
+  for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
+    local test_match = {}
+    for id, node in pairs(match) do
+      local capture = test_query.captures[id]
+      if capture == "testname" then
+        local name = vim.treesitter.get_node_text(node, 0)
+        test_match.name = name
+      end
+      if capture == "parent" then
+        test_match.node = node
+      end
+    end
+    table.insert(test_tree, test_match)
+  end
+
+  local subtest_query = vim.treesitter.query.parse(ft, subtests_query)
+  assert(subtest_query, 'could not parse test query')
+  for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row) do
+    local test_match = {}
+    for id, node in pairs(match) do
+      local capture = subtest_query.captures[id]
+      if capture == "testname" then
+        local name = vim.treesitter.get_node_text(node, 0)
+        test_match.name = string.gsub(string.gsub(name, ' ', '_'), '"', '')
+      end
+      if capture == "parent" then
+        test_match.node = node
+      end
+    end
+    table.insert(test_tree, test_match)
+  end
+
+  table.sort(test_tree, function(a, b)
+    return is_parent(a.node, b.node)
+  end)
+
+  for _, parent in ipairs(test_tree) do
+    for _, child in ipairs(test_tree) do
+      if is_parent(parent.node, child.node) then
+        child.parent = parent.name
+      end
+    end
+  end
+
+  return get_closest_above_cursor(test_tree)
+end
+
+local function get_package_name()
+  local test_dir = vim.fn.fnamemodify(vim.fn.expand("%:.:h"), ":r");
+  return "./" .. test_dir
+end
+
+M.closest_test = function()
+  local package_name = get_package_name()
+  local test_case = get_closest_test()
+  local test_scope
+  if test_case then
+    test_scope = "testcase"
+  else
+    test_scope = "package"
+  end
+  return {
+    package = package_name,
+    name = test_case,
+    scope = test_scope,
+  }
+end
+
+M.get_root_dir = function()
+  local id, client = next(vim.lsp.buf_get_clients())
+  if id == nil then
+    error({ error_msg = "lsp client not attached" })
+  end
+  if not client.config.root_dir then
+    error({ error_msg = "lsp root_dir not defined" })
+  end
+  return client.config.root_dir
+end
+
+return M

--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -134,7 +134,7 @@ local function get_closest_test()
 end
 
 local function get_package_name()
-  local test_dir = vim.fn.fnamemodify(vim.fn.expand("%:.:h"), ":r");
+  local test_dir = vim.fn.fnamemodify(vim.fn.expand("%:.:h"), ":r")
   return "./" .. test_dir
 end
 

--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -77,15 +77,15 @@ end
 
 local function get_closest_test()
   local stop_row = vim.api.nvim_win_get_cursor(0)[1]
-  local ft = vim.api.nvim_buf_get_option(0, 'filetype')
-  assert(ft == 'go', 'can only find test in go files, not ' .. ft)
+  local ft = vim.api.nvim_buf_get_option(0, "filetype")
+  assert(ft == "go", "can only find test in go files, not " .. ft)
   local parser = vim.treesitter.get_parser(0)
   local root = (parser:parse()[1]):root()
 
   local test_tree = {}
 
   local test_query = vim.treesitter.query.parse(ft, tests_query)
-  assert(test_query, 'could not parse test query')
+  assert(test_query, "could not parse test query")
   for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
     local test_match = {}
     for id, node in pairs(match) do
@@ -102,14 +102,14 @@ local function get_closest_test()
   end
 
   local subtest_query = vim.treesitter.query.parse(ft, subtests_query)
-  assert(subtest_query, 'could not parse test query')
+  assert(subtest_query, "could not parse test query")
   for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row) do
     local test_match = {}
     for id, node in pairs(match) do
       local capture = subtest_query.captures[id]
       if capture == "testname" then
         local name = vim.treesitter.get_node_text(node, 0)
-        test_match.name = string.gsub(string.gsub(name, ' ', '_'), '"', '')
+        test_match.name = string.gsub(string.gsub(name, " ", "_"), '"', "")
       end
       if capture == "parent" then
         test_match.node = node

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -1,3 +1,5 @@
+local ts = require "dap-go-ts"
+
 local M = {
   last_testname = "",
   last_testpath = "",
@@ -13,27 +15,6 @@ local default_config = {
     build_flags = "",
   },
 }
-
-local tests_query = [[
-(function_declaration
-  name: (identifier) @testname
-  parameters: (parameter_list
-    . (parameter_declaration
-      type: (pointer_type) @type) .)
-  (#match? @type "*testing.(T|M)")
-  (#match? @testname "^Test.+$")) @parent
-]]
-
-local subtests_query = [[
-(call_expression
-  function: (selector_expression
-    operand: (identifier)
-    field: (field_identifier) @run)
-  arguments: (argument_list
-    (interpreted_string_literal) @testname
-    (func_literal))
-  (#eq? @run "Run")) @parent
-]]
 
 local function load_module(module_name)
   local ok, module = pcall(require, module_name)
@@ -170,122 +151,20 @@ local function debug_test(testname, testpath, build_flags)
   })
 end
 
-local function get_closest_above_cursor(test_tree)
-  local result
-  for _, curr in pairs(test_tree) do
-    if not result then
-      result = curr
-    else
-      local node_row1, _, _, _ = curr.node:range()
-      local result_row1, _, _, _ = result.node:range()
-      if node_row1 > result_row1 then
-        result = curr
-      end
-    end
-  end
-  if result == nil then
-    return ""
-  elseif result.parent then
-    return string.format("%s/%s", result.parent, result.name)
-  else
-    return result.name
-  end
-end
-
-local function is_parent(dest, source)
-  if not (dest and source) then
-    return false
-  end
-  if dest == source then
-    return false
-  end
-
-  local current = source
-  while current ~= nil do
-    if current == dest then
-      return true
-    end
-
-    current = current:parent()
-  end
-
-  return false
-end
-
-local function get_closest_test()
-  local stop_row = vim.api.nvim_win_get_cursor(0)[1]
-  local ft = vim.api.nvim_buf_get_option(0, "filetype")
-  assert(ft == "go", "dap-go error: can only debug go files, not " .. ft)
-  local parser = vim.treesitter.get_parser(0)
-  local root = (parser:parse()[1]):root()
-
-  local test_tree = {}
-
-  local test_query = vim.treesitter.query.parse(ft, tests_query)
-  assert(test_query, "dap-go error: could not parse test query")
-  for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
-    local test_match = {}
-    for id, node in pairs(match) do
-      local capture = test_query.captures[id]
-      if capture == "testname" then
-        local name = vim.treesitter.get_node_text(node, 0)
-        test_match.name = name
-      end
-      if capture == "parent" then
-        test_match.node = node
-      end
-    end
-    table.insert(test_tree, test_match)
-  end
-
-  local subtest_query = vim.treesitter.query.parse(ft, subtests_query)
-  assert(subtest_query, "dap-go error: could not parse test query")
-  for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row) do
-    local test_match = {}
-    for id, node in pairs(match) do
-      local capture = subtest_query.captures[id]
-      if capture == "testname" then
-        local name = vim.treesitter.get_node_text(node, 0)
-        test_match.name = string.gsub(string.gsub(name, " ", "_"), '"', "")
-      end
-      if capture == "parent" then
-        test_match.node = node
-      end
-    end
-    table.insert(test_tree, test_match)
-  end
-
-  table.sort(test_tree, function(a, b)
-    return is_parent(a.node, b.node)
-  end)
-
-  for _, parent in ipairs(test_tree) do
-    for _, child in ipairs(test_tree) do
-      if is_parent(parent.node, child.node) then
-        child.parent = parent.name
-      end
-    end
-  end
-
-  return get_closest_above_cursor(test_tree)
-end
-
 function M.debug_test()
-  local testname = get_closest_test()
-  local relativeFileDirname = vim.fn.fnamemodify(vim.fn.expand("%:.:h"), ":r")
-  local testpath = string.format("./%s", relativeFileDirname)
+  local test = ts.closest_test()
 
-  if testname == "" then
+  if test.name == "" then
     vim.notify("no test found")
     return false
   end
 
-  M.last_testname = testname
-  M.last_testpath = testpath
+  M.last_testname = test.name
+  M.last_testpath = test.package
 
-  local msg = string.format("starting debug session '%s : %s'...", testpath, testname)
+  local msg = string.format("starting debug session '%s : %s'...", test.package, test.name)
   vim.notify(msg)
-  debug_test(testname, testpath, M.test_buildflags)
+  debug_test(test.name, test.package, M.test_buildflags)
 
   return true
 end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -1,4 +1,4 @@
-local ts = require "dap-go-ts"
+local ts = require("dap-go-ts")
 
 local M = {
   last_testname = "",


### PR DESCRIPTION
This PR allows debugging a single nested test.
It also refactor the code separating all treesitter logic in a dedicated file.

fix: https://github.com/leoluz/nvim-dap-go/issues/39

