### PR TITLE
Handle nil test.name

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -145,7 +145,7 @@ end
 function M.debug_test()
   local test = ts.closest_test()
 
-  if test.name == "" then
+  if test.name == "" or test.name == nil then
     vim.notify("no test found")
     return false
   end


### PR DESCRIPTION
I assume the treesitter API changed (again) and caused this to start breaking. If I try to run `debug_test()` outside of a test file, then I get an exception for trying to concatenate a nil value. This commit just fixes the "no test found" short-circuit clause to handle empty string or nil.