### PR TITLE
Added detached option to fix windows error

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ lua require('dap-go').setup {
     -- passing build flags using args is ineffective, as those are
     -- ignored by delve in dap mode.
     build_flags = "",
+    -- whether the dlv process to be created detached or not. there is
+    -- an issue on Windows where this needs to be set to false
+    -- otherwise the dlv server creation will fail.
+    detached = true
   },
 }
 ```

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -80,9 +80,20 @@ The example bellow shows all the possible configurations:
         -- a string that defines the port to start delve debugger.
         -- default to string "${port}" which instructs nvim-dap
         -- to start the process in a random available port
-        port = "${port}"
+        port = "${port}",
         -- additional args to pass to dlv
-        args = {}
+        args = {},
+        -- the build flags that are passed to delve.
+        -- defaults to empty string, but can be used to provide flags
+        -- such as "-tags=unit" to make sure the test suite is
+        -- compiled during debugging, for example.
+        -- passing build flags using args is ineffective, as those are
+        -- ignored by delve in dap mode.
+        build_flags = "",
+        -- whether the dlv process to be created detached or not. there is
+        -- an issue on Windows where this needs to be set to false
+        -- otherwise the dlv server creation will fail.
+        detached = true
       },
     }
 <

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -13,6 +13,7 @@ local default_config = {
     port = "${port}",
     args = {},
     build_flags = "",
+    detached = true,
   },
 }
 
@@ -53,6 +54,7 @@ local function setup_delve_adapter(dap, config)
     executable = {
       command = config.delve.path,
       args = args,
+      detached = config.delve.detached,
     },
     options = {
       initialize_timeout_sec = config.delve.initialize_timeout_sec,


### PR DESCRIPTION
- fixes: https://github.com/leoluz/nvim-dap-go/issues/66

Added the `detached` option so that the windows users can set it to `false` in order to solve the dlv error.