### PR TITLE
feat: add debug_config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ lua require('dap-go').setup {
     -- ignored by delve in dap mode.
     build_flags = "",
   },
+
+  -- When debugging tests, nvim-dap-go will use a custom launch configuration
+  -- not included in `dap_configurations`.
+  -- You can use the following option to add extra configuration arguments
+  -- for when running tests in debug mode.
+  -- This table is merged with the default debug launch configuration, 
+  -- overriding any existing values.
+  extra_debug_opts = {
+    env = {
+      MY_ENV_VAR = "value",
+    },
+    cwd = "${workspaceFolder}",
+  }
 }
 ```
 
@@ -90,11 +103,12 @@ lua require('dap-go').setup {
 
 ### Debugging individual tests
 
-
 To debug the closest method above the cursor use you can run:
+
 - `:lua require('dap-go').debug_test()`
 
 Once a test was run, you can simply run it again from anywhere:
+
 - `:lua require('dap-go').debug_last_test()`
 
 It is better to define a mapping to invoke this command. See the mapping section below.
@@ -112,6 +126,7 @@ It is better to define a mapping to invoke this command. See the mapping section
 ### Debugging with dlv in headless mode
 
 1. Register a new option to attach to a remote debugger:
+
 ```lua
 lua require('dap-go').setup {
   dap_configurations = {
@@ -124,10 +139,13 @@ lua require('dap-go').setup {
   },
 }
 ```
+
 1. Start `dlv` in headless mode. You can specify subcommands and flags after `--`, e.g.,
+
 ```sh
 dlv debug -l 127.0.0.1:38697 --headless ./main.go -- subcommand --myflag=xyz
 ```
+
 1. Call `:lua require('dap').continue()` to start debugging.
 1. Select the new registered option `Attach remote`.
 

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -124,14 +124,15 @@ end
 function M.setup(opts)
   local config = vim.tbl_deep_extend("force", default_config, opts or {})
   M.test_buildflags = config.delve.build_flags
+  M.extra_debug_opts = config.extra_debug_opts
   local dap = load_module("dap")
   setup_delve_adapter(dap, config)
   setup_go_configuration(dap, config)
 end
 
-local function debug_test(testname, testpath, build_flags)
+local function debug_test(testname, testpath, build_flags, extra_debug_opts)
   local dap = load_module("dap")
-  dap.run({
+  local run_config = {
     type = "go",
     name = testname,
     request = "launch",
@@ -139,7 +140,10 @@ local function debug_test(testname, testpath, build_flags)
     program = testpath,
     args = { "-test.run", "^" .. testname .. "$" },
     buildFlags = build_flags,
-  })
+  }
+  run_config = vim.tbl_deep_extend("force", run_config, extra_debug_opts or {})
+  vim.notify(vim.inspect(extra_debug_opts))
+  dap.run(run_config)
 end
 
 function M.debug_test()
@@ -155,7 +159,7 @@ function M.debug_test()
 
   local msg = string.format("starting debug session '%s : %s'...", test.package, test.name)
   vim.notify(msg)
-  debug_test(test.name, test.package, M.test_buildflags)
+  debug_test(test.name, test.package, M.test_buildflags, M.extra_debug_opts)
 
   return true
 end


### PR DESCRIPTION
This PR adds a `extra_debug_opts` configuration to setup that allows passing extra arguments for the `debug_test()` launch configuration. 

Fixes #76 
