### PR TITLE
Set the Delve port dynamically for remote debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,7 @@ nmap <silent> <leader>td :lua require('dap-go').debug_test()<CR>
 ## VSCode launch config
 
 Defining the Go debug configurations for all your projects inside your Neovim configuration can be cumbersome and quite strict.
-For more flexibility, `nvim-dap` supports the use of the VSCode launch configurations. To use that feature in combination with the predefined `nvim-dap-go` configurations (the ones for launching debug sessions in tests for instance), load the VSCode configurations **BEFORE** calling the `setup()` function of `nvim-dap-go`:
-
-```lua
-require("dap.ext.vscode").load_launchjs()
-require("dap-go").setup()
-```
+For more flexibility, `nvim-dap` supports the use of the VSCode launch configurations.
 
 That allows for example to set the Delve port dynamically when you run a debug session. If you create this file in your project (`[root_project]/.vscode/launch.json`):
 
@@ -233,6 +228,7 @@ That allows for example to set the Delve port dynamically when you run a debug s
 ```
 
 A debug session `Remote debug API server` will appear in the choices, and the Delve port will be dynamically set to `4444`.
+The current version of nvim-dap always loads the file if it exists.
 
 Please see `:h dap-launch.json` for more information.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ nmap <silent> <leader>td :lua require('dap-go').debug_test()<CR>
 ## VSCode launch config
 
 Defining the Go debug configurations for all your projects inside your Neovim configuration can be cumbersome and quite strict.
-For more flexibility, `nvim-dap` supports the use of the VSCode launch configurations. To use that feature in combination with the pre-defined `nvim-dap-go` configurations (the ones for launching debug sessions in tests for instance), load the VSCode configurations **BEFORE** calling the `setup()` function of `nvim-dap-go`:
+For more flexibility, `nvim-dap` supports the use of the VSCode launch configurations. To use that feature in combination with the predefined `nvim-dap-go` configurations (the ones for launching debug sessions in tests for instance), load the VSCode configurations **BEFORE** calling the `setup()` function of `nvim-dap-go`:
 
 ```lua
 require("dap.ext.vscode").load_launchjs()

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An extension for [nvim-dap][1] providing configurations for launching go debugge
 - Configuration to attach nvim-dap and Delve into a running process and start a debug session.
 - Configuration to start a debug session in the main function.
 - Configuration to run tests in a debug session.
+- Final Delve configuration is resolved when a debug session starts. This allows to use different addresses and ports for each project or launch configs in a project.
 
 ## Pre-reqs
 
@@ -67,7 +68,9 @@ lua require('dap-go').setup {
     initialize_timeout_sec = 20,
     -- a string that defines the port to start delve debugger.
     -- default to string "${port}" which instructs nvim-dap
-    -- to start the process in a random available port
+    -- to start the process in a random available port.
+    -- if you set a port in your debug configuration, its value will be
+    -- assigned dynamically.
     port = "${port}",
     -- additional args to pass to dlv
     args = {},
@@ -195,6 +198,43 @@ dlv debug -l 127.0.0.1:38697 --headless ./main.go -- subcommand --myflag=xyz
 ```vimL
 nmap <silent> <leader>td :lua require('dap-go').debug_test()<CR>
 ```
+
+## VSCode launch config
+
+Defining the Go debug configurations for all your projects inside your Neovim configuration can be cumbersome and quite strict.
+For more flexibility, `nvim-dap` supports the use of the VSCode launch configurations. To use that feature in combination with the pre-defined `nvim-dap-go` configurations (the ones for launching debug sessions in tests for instance), load the VSCode configurations **BEFORE** calling the `setup()` function of `nvim-dap-go`:
+
+```lua
+require("dap.ext.vscode").load_launchjs()
+require("dap-go").setup()
+```
+
+That allows for example to set the Delve port dynamically when you run a debug session. If you create this file in your project (`[root_project]/.vscode/launch.json`):
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Remote debug API server",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 4444,
+            "host": "127.0.0.1",
+            "substitutePath": [
+                {
+                    "from": "${workspaceFolder}", "to": "/usr/src/app"
+                }
+            ]
+        }
+    ]
+}
+```
+
+A debug session `Remote debug API server` will appear in the choices, and the Delve port will be dynamically set to `4444`.
+
+Please see `:h dap-launch.json` for more information.
 
 ## Acknowledgement
 

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -17,7 +17,8 @@ CONTENTS                                                  *dap-go-toc*
     5. Debugging With Command-Line Arguments . |dap-go-debug-cli-args|
     6. Debugging With Build Flags ............ |dap-go-debug-cli-args|
     7. Debugging With dlv in Headless Mode ... |dap-go-debug-headless|
-    8. Mappings .............................. |dap-go-mappings|
+    8. VSCode launch config .................. |dap-go-vscode-launch|
+    9. Mappings .............................. |dap-go-mappings|
 
 ========================================================================
 FEATURES                                             *dap-go-features*
@@ -35,6 +36,10 @@ FEATURES                                             *dap-go-features*
 - Configuration to start a debug session in the main function.
 
 - Configuration to run tests in a debug session.
+
+- Final Delve configuration is resolved when a debug session starts.
+  This allows to use different addresses and ports for each project or
+  launch configs in a project.
 
 This plugin makes usage of treesitter to find the nearest test to
 debug. Make sure you have the Go treesitter parser installed. If using
@@ -80,7 +85,9 @@ The example bellow shows all the possible configurations:
         initialize_timeout_sec = 20,
         -- a string that defines the port to start delve debugger.
         -- default to string "${port}" which instructs nvim-dap
-        -- to start the process in a random available port
+        -- to start the process in a random available port.
+        -- if you set a port in your debug configuration, its value will be
+        -- assigned dynamically.
         port = "${port}",
         -- additional args to pass to dlv
         args = {},
@@ -207,6 +214,45 @@ Debugging With dlv in Headless Mode           *dap-go-debug-headless*
     3. Call `:lua require('dap').continue()` to start debugging.
     4. Select the new registered option `Attach remote`.
 
+-----------------------------------------------------------------------
+VSCode launch config                           *dap-go-vscode-launch
+
+    1. In your neovim configuration, load the VSCode extension BEFORE
+    calling the `setup()` function:
+>lua
+    require("dap.ext.vscode").load_launchjs()
+    require("dap-go").setup()
+<
+
+    2. Create in your Go project a VSCode launch config file (by
+    default its path must be `.vscode/launch.json` relative to your
+    project's root directory):
+>json
+    {
+        "version": "0.2.0",
+        "configurations": [
+            {
+                "name": "Remote debug API server",
+                "type": "go",
+                "request": "attach",
+                "mode": "remote",
+                "port": 4444,
+                "host": "127.0.0.1",
+                "substitutePath": [
+                    {
+                        "from": "${workspaceFolder}", "to": "/usr/src/app"
+                    }
+                ]
+            }
+        ]
+    }
+<
+
+    3. A debug session `Remote debug API server` will appear in the choices,
+    and the Delve port will be dynamically set to `4444`.
+
+Please see `:h dap-launch.json` for more information.
+
 ========================================================================
 MAPPINGS                                             *dap-go-mappings*
 
@@ -220,5 +266,4 @@ mappings. You can do this by adding the lines bellow to your
     vim.keymap.set("n", "<leader>dt", dapgo.debug_test)
     vim.keymap.set("n", "<leader>dl", dapgo.debug_last_test)
 <
-
 vim:tw=78:et:ft=help:norl:

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -217,14 +217,7 @@ Debugging With dlv in Headless Mode           *dap-go-debug-headless*
 -----------------------------------------------------------------------
 VSCode launch config                           *dap-go-vscode-launch
 
-    1. In your neovim configuration, load the VSCode extension BEFORE
-    calling the `setup()` function:
->lua
-    require("dap.ext.vscode").load_launchjs()
-    require("dap-go").setup()
-<
-
-    2. Create in your Go project a VSCode launch config file (by
+    1. Create in your Go project a VSCode launch config file (by
     default its path must be `.vscode/launch.json` relative to your
     project's root directory):
 >json
@@ -248,7 +241,7 @@ VSCode launch config                           *dap-go-vscode-launch
     }
 <
 
-    3. A debug session `Remote debug API server` will appear in the choices,
+    2. A debug session `Remote debug API server` will appear in the choices,
     and the Delve port will be dynamically set to `4444`.
 
 Please see `:h dap-launch.json` for more information.

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -81,25 +81,17 @@ local function setup_delve_adapter(dap, config)
   }
 
   dap.adapters.go = function(callback, client_config)
-    local required_fields = {
-      "mode",
-      "port",
-      "host",
-    }
-
-    for _, field in ipairs(required_fields) do
-      if client_config[field] == nil then
-        vim.notify(string.format("missing DAP config key %s", field), vim.log.levels.ERROR)
-        return
-      end
-    end
-
-    if client_config.mode ~= "remote" then
+    if client_config.port == nil then
       callback(delve_config)
       return
     end
 
-    local listener_addr = client_config.host .. ":" .. client_config.port
+    local host = client_config.host
+    if host == nil then
+      host = "127.0.0.1"
+    end
+
+    local listener_addr = host .. ":" .. client_config.port
     delve_config.port = client_config.port
     delve_config.executable.args = { "dap", "-l", listener_addr }
 

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -152,6 +152,10 @@ local function setup_go_configuration(dap, configs)
     },
   }
 
+  if dap.configurations.go == nil then
+    dap.configurations.go = {}
+  end
+
   for _, config in ipairs(common_debug_configs) do
     table.insert(dap.configurations.go, config)
   end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -81,6 +81,19 @@ local function setup_delve_adapter(dap, config)
   }
 
   dap.adapters.go = function(callback, client_config)
+    local required_fields = {
+      "mode",
+      "port",
+      "host",
+    }
+
+    for _, field in ipairs(required_fields) do
+      if client_config[field] == nil then
+        vim.notify(string.format("missing DAP config key %s", field), vim.log.levels.ERROR)
+        return
+      end
+    end
+
     if client_config.mode ~= "remote" then
       callback(delve_config)
       return


### PR DESCRIPTION
Currently the Delve port can be defined either randomly or hard-coded by hand.

Hard-coded port allows to know which port to use in remote debug configurations, but in practice with many Go projects, it would be great to set the Delve port in debug configurations.

Luckily `nvim-dap` allows to set an `on_config` callback for an adapter, which can be used to resolve the adapter settings when a debug session starts. This PR implements this `nvim-dap` feature, which can be used with the support of VSCode `launch.json` files to greatly enhance the developer experience.

This potentially resolves https://github.com/leoluz/nvim-dap-go/issues/73