### PR TITLE
fix(sub-tests): supports subtests with an identifier

### DIFF
--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -17,7 +17,10 @@ local subtests_query = [[
     field: (field_identifier) @run)
   arguments: (argument_list
     (interpreted_string_literal) @testname
-    (func_literal))
+    [
+     (func_literal)
+     (identifier)
+    ])
   (#eq? @run "Run")) @parent
 ]]
 


### PR DESCRIPTION
The `:lua require('dap-go').debug_test()` function is not working for all sub tests. That is because right now, the TreeSitter [subtests_query](https://github.com/leoluz/nvim-dap-go/blob/main/lua/dap-go-ts.lua#L13) is written with just a `func_literal` in the `arguments`'s `call_expression`.
It is often the case to use it with a `literal`, see example below: 

```go
package test

import (
	"testing"
)

func TestWithSubTests(t *testing.T) {
	t.Run("subtest with function literal (is already working)", func(t *testing.T) {})
	myFunc := func(t *testing.T) {}
	t.Run("subtest with identifier", myFunc)
}
```

Previously, running `:lua require('dap-go').debug_test()` with the cursor on the line with `t.Run("subtest with identifier", myFunc)` was running the parent test `TestWithSubTests` which is running all subtests.
WIth this pull request, now running the `debug_test()` is going to run the test `subtest with identifier` only.