### PR TITLE
fix: automatically set attached mode for delve based on OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ lua require('dap-go').setup {
     -- whether the dlv process to be created detached or not. there is
     -- an issue on Windows where this needs to be set to false
     -- otherwise the dlv server creation will fail.
-    detached = vim.fn.has 'win32' == 0
+    detached = vim.fn.has("win32") == 0,
     -- the current working directory to run dlv from, if other than
     -- the current working directory.
     cwd = nil,

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ lua require('dap-go').setup {
     -- whether the dlv process to be created detached or not. there is
     -- an issue on Windows where this needs to be set to false
     -- otherwise the dlv server creation will fail.
-    detached = true
+    detached = vim.fn.has 'win32' == 0
     -- the current working directory to run dlv from, if other than
     -- the current working directory.
     cwd = nil,

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -14,7 +14,7 @@ local default_config = {
     args = {},
     build_flags = "",
     -- Automativally handle the issue on Windows where delve needs
-    -- to be run in attched mode or it will fail (actuall crash).
+    -- to be run in attched mode or it will fail (actually crashes).
     detached = vim.fn.has("win32") == 0,
   },
 }

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -13,7 +13,9 @@ local default_config = {
     port = "${port}",
     args = {},
     build_flags = "",
-    detached = true,
+    -- Automativally handle the issue on Windows where delve needs
+    -- to be run in attched mode or it will fail (actuall crash).
+    detached = vim.fn.has("win32") == 0,
   },
 }
 


### PR DESCRIPTION
Hi,

Here's a change to automatically set the attached mode for delve so the end-user doesn't have to.

I added it to the config example too but maybe that entire line should be removed with this fix in place, let me know if I should do that.

Br,