### PR TITLE
feat: Add configuration to enable tests verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ lua require('dap-go').setup {
 
 ### Debugging individual tests
 
+
 To debug the closest method above the cursor use you can run:
 - `:lua require('dap-go').debug_test()`
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ lua require('dap-go').setup {
     -- the current working directory.
     cwd = nil,
   },
+  -- options related to running closest test
+  tests = {
+    -- enables verbosity when running the test.
+    verbose = false,
+  },
 }
 ```
 
@@ -97,11 +102,12 @@ lua require('dap-go').setup {
 
 ### Debugging individual tests
 
-
 To debug the closest method above the cursor use you can run:
+
 - `:lua require('dap-go').debug_test()`
 
 Once a test was run, you can simply run it again from anywhere:
+
 - `:lua require('dap-go').debug_last_test()`
 
 It is better to define a mapping to invoke this command. See the mapping section below.
@@ -119,6 +125,7 @@ It is better to define a mapping to invoke this command. See the mapping section
 ### Debugging with dlv in headless mode
 
 1. Register a new option to attach to a remote debugger:
+
 ```lua
 lua require('dap-go').setup {
   dap_configurations = {
@@ -131,10 +138,13 @@ lua require('dap-go').setup {
   },
 }
 ```
+
 1. Start `dlv` in headless mode. You can specify subcommands and flags after `--`, e.g.,
+
 ```sh
 dlv debug -l 127.0.0.1:38697 --headless ./main.go -- subcommand --myflag=xyz
 ```
+
 1. Call `:lua require('dap').continue()` to start debugging.
 1. Select the new registered option `Attach remote`.
 

--- a/README.md
+++ b/README.md
@@ -103,11 +103,9 @@ lua require('dap-go').setup {
 ### Debugging individual tests
 
 To debug the closest method above the cursor use you can run:
-
 - `:lua require('dap-go').debug_test()`
 
 Once a test was run, you can simply run it again from anywhere:
-
 - `:lua require('dap-go').debug_last_test()`
 
 It is better to define a mapping to invoke this command. See the mapping section below.
@@ -125,7 +123,6 @@ It is better to define a mapping to invoke this command. See the mapping section
 ### Debugging with dlv in headless mode
 
 1. Register a new option to attach to a remote debugger:
-
 ```lua
 lua require('dap-go').setup {
   dap_configurations = {
@@ -138,13 +135,10 @@ lua require('dap-go').setup {
   },
 }
 ```
-
 1. Start `dlv` in headless mode. You can specify subcommands and flags after `--`, e.g.,
-
 ```sh
 dlv debug -l 127.0.0.1:38697 --headless ./main.go -- subcommand --myflag=xyz
 ```
-
 1. Call `:lua require('dap').continue()` to start debugging.
 1. Select the new registered option `Attach remote`.
 

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -95,6 +95,11 @@ The example bellow shows all the possible configurations:
         -- otherwise the dlv server creation will fail.
         detached = true
       },
+      -- options related to running closest test
+      tests = {
+        -- enables verbosity when running the test.
+        verbose = false,
+      },
     }
 <
 

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -147,7 +147,7 @@ local function setup_go_configuration(dap, configs)
     if config.type == "go" then
       table.insert(dap.configurations.go, config)
     end
-  end_delve_adapter(dap, internal_global_confi
+  end
 end
 
 function M.setup(opts)


### PR DESCRIPTION
I really like the feature of running the closest test to the cursor.

However, I usually make use of the `t.Logf` method which logs stuff when running tests. Without verbosity being turned on these logs will only show when the tests fail.

This PR adds an option to the plugin to enable verbosity. It sets this option to false by default so as to not change the behaviour of the plugin.