### PR TITLE
fix: do not add executable to adapter in launch request

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -14,8 +14,8 @@ local default_config = {
     port = "${port}",
     args = {},
     build_flags = "",
-    -- Automativally handle the issue on Windows where delve needs
-    -- to be run in attched mode or it will fail (actually crashes).
+    -- Automatically handle the issue on Windows where delve needs
+    -- to be run in attached mode or it will fail (actually crashes).
     detached = vim.fn.has("win32") == 0,
   },
   tests = {
@@ -89,6 +89,12 @@ local function setup_delve_adapter(dap, config)
     local host = client_config.host
     if host == nil then
       host = "127.0.0.1"
+    end
+
+    -- Remove the executable if used in remote mode.
+    -- This will prevent the executable from being launched.
+    if client_config.mode == "remote" then
+      delve_config.executable = nil
     end
 
     local listener_addr = host .. ":" .. client_config.port


### PR DESCRIPTION
The adapter would add the `executable` property to the adapter regardless of whether the request was `launch` or `attach`. When `attach` was used, it would attempt to start `dlv` on the same port that it was attempting to configure.

This changes it so the executable is not added if `attach` is used and adds some protection code to prevent the random port assignment from being used with the attach configuration (where it wouldn't work anyway).

Fixes issue mentioned here: https://github.com/leoluz/nvim-dap-go/issues/35#issuecomment-2135780713
Solution suggested here: https://github.com/mfussenegger/nvim-dap/pull/1273#issuecomment-2192063929