### PR TITLE
fix(closest_test): uses new behavior of the iter_matches function

### DIFF
--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -86,16 +86,18 @@ local function get_closest_test()
 
   local test_query = vim.treesitter.query.parse(ft, tests_query)
   assert(test_query, "could not parse test query")
-  for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row) do
+  for _, match, _ in test_query:iter_matches(root, 0, 0, stop_row, { all = true }) do
     local test_match = {}
-    for id, node in pairs(match) do
-      local capture = test_query.captures[id]
-      if capture == "testname" then
-        local name = vim.treesitter.get_node_text(node, 0)
-        test_match.name = name
-      end
-      if capture == "parent" then
-        test_match.node = node
+    for id, nodes in pairs(match) do
+      for _, node in ipairs(nodes) do
+        local capture = test_query.captures[id]
+        if capture == "testname" then
+          local name = vim.treesitter.get_node_text(node, 0)
+          test_match.name = name
+        end
+        if capture == "parent" then
+          test_match.node = node
+        end
       end
     end
     table.insert(test_tree, test_match)
@@ -103,16 +105,18 @@ local function get_closest_test()
 
   local subtest_query = vim.treesitter.query.parse(ft, subtests_query)
   assert(subtest_query, "could not parse test query")
-  for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row) do
+  for _, match, _ in subtest_query:iter_matches(root, 0, 0, stop_row, { all = true }) do
     local test_match = {}
-    for id, node in pairs(match) do
-      local capture = subtest_query.captures[id]
-      if capture == "testname" then
-        local name = vim.treesitter.get_node_text(node, 0)
-        test_match.name = string.gsub(string.gsub(name, " ", "_"), '"', "")
-      end
-      if capture == "parent" then
-        test_match.node = node
+    for id, nodes in pairs(match) do
+      for _, node in ipairs(nodes) do
+        local capture = subtest_query.captures[id]
+        if capture == "testname" then
+          local name = vim.treesitter.get_node_text(node, 0)
+          test_match.name = string.gsub(string.gsub(name, " ", "_"), '"', "")
+        end
+        if capture == "parent" then
+          test_match.node = node
+        end
       end
     end
     table.insert(test_tree, test_match)


### PR DESCRIPTION
See Neovim breaking change PR: https://github.com/neovim/neovim/pull/30193

Now `iter_matches` by default returns a list of node. 
Iterates over all nodes with backward compatibility using the `all = true` option.

Fixes https://github.com/leoluz/nvim-dap-go/issues/96