### PR TITLE
feat: set cwd for dlv based on program

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -62,25 +62,6 @@ local function filtered_pick_process()
   return require("dap.utils").pick_process(opts)
 end
 
-local get_parent = (function()
-  local sep = "\\"
-
-  local os = string.lower(jit.os)
-  if os ~= "windows" then
-    sep = "/"
-  end
-
-  local pattern = string.format("^(.+)%s[^%s]+", sep, sep)
-
-  return function(abs_path)
-    local parent = abs_path:match(pattern)
-    if parent ~= nil and not parent:find(sep) then
-      return parent .. sep
-    end
-    return parent
-  end
-end)()
-
 local function setup_delve_adapter(dap, config)
   local args = { "dap", "-l", "127.0.0.1:" .. config.delve.port }
   vim.list_extend(args, config.delve.args)
@@ -109,8 +90,8 @@ local function setup_delve_adapter(dap, config)
         local is_dir = vim.loop.fs_stat(program_absolute).type == "directory"
         if is_dir then
           delve_config.executable.cwd = program_absolute
-        elseif program_absolute:sub(-3) == ".go" then -- file extension is '.go'
-          local parent = get_parent(program_absolute)
+        elseif vim.fn.fnamemodify(program_absolute, ":e") == ".go" then -- file extension is '.go'
+          local parent = vim.fn.fnamemodify(program_absolute, ":p:h")
           if parent ~= nil then
             delve_config.executable.cwd = parent
           end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -81,6 +81,21 @@ local function setup_delve_adapter(dap, config)
   }
 
   dap.adapters.go = function(callback, client_config)
+    if client_config.program ~= nil then
+      local program = client_config.program
+      local path = require("plenary.path")
+      local program_path = path:new(program)
+      local program_absolute = program_path:absolute()
+
+      client_config.program = program_absolute
+
+      if program_path:is_dir() then
+        delve_config.executable.cwd = program_absolute
+      elseif program:match("^.+(%..+)$") == ".go" then -- file extension is '.go'
+        delve_config.executable.cwd = tostring(program_path:parent())
+      end
+    end
+
     if client_config.port == nil then
       callback(delve_config)
       return

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -90,7 +90,7 @@ local function setup_delve_adapter(dap, config)
         local is_dir = vim.loop.fs_stat(program_absolute).type == "directory"
         if is_dir then
           delve_config.executable.cwd = program_absolute
-        elseif vim.fn.fnamemodify(program_absolute, ":e") == ".go" then -- file extension is '.go'
+        elseif vim.fn.fnamemodify(program_absolute, ":e") == "go" then -- file extension is '.go'
           local parent = vim.fn.fnamemodify(program_absolute, ":p:h")
           if parent ~= nil then
             delve_config.executable.cwd = parent


### PR DESCRIPTION
This potentially resolves #85.

- Similar to vscode-go, set `dlv.executable.cwd` based on the value of `debug_config.program`. If `program` is a directory, set `cwd` to `program`. If `program` is a path to a go file, set `cwd` to its parent directory.
- Convert `program` to absolute path.

We probably don't need `config.delve.cwd` anymore.

Reference: https://github.com/golang/vscode-go/blob/master/extension/src/goDebugConfiguration.ts#L545