### PR TITLE
[bug] Fix Remote Debug Connection

### DIFF
--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -92,10 +92,18 @@ local function setup_delve_adapter(dap, config)
     end
 
     local listener_addr = host .. ":" .. client_config.port
-    delve_config.port = client_config.port
-    delve_config.executable.args = { "dap", "-l", listener_addr }
+    local dlv_cfg = {
+      type = delve_config.type,
+      port = client_config.port,
+      options = delve_config.options,
+    }
 
-    callback(delve_config)
+    if client_config.mode ~= "remote" then
+      dlv_cfg.executable = delve_config.executable
+      dlv_cfg.executable.args = { "dap", "-l", listener_addr }
+    end
+
+    callback(dlv_cfg)
   end
 end
 


### PR DESCRIPTION
Introduce `dlv_cfg` var to allow us to decide if we should use the `executable` config, in the case of a remote connection we do not want to make use of this.