### PR TITLE
Updated comments for delve Windows detached issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ lua require('dap-go').setup {
     -- avaliable ui interactive function to prompt for arguments get_arguments
     build_flags = {},
     -- whether the dlv process to be created detached or not. there is
-    -- an issue on Windows where this needs to be set to false
-    -- otherwise the dlv server creation will fail.
+    -- an issue on delve versions < 1.24.0 for Windows where this needs to be
+    -- set to false, otherwise the dlv server creation will fail.
     -- avaliable ui interactive function to prompt for build flags: get_build_flags
     detached = vim.fn.has("win32") == 0,
     -- the current working directory to run dlv from, if other than

--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -99,9 +99,9 @@ The example bellow shows all the possible configurations:
         -- ignored by delve in dap mode.
         build_flags = "",
         -- whether the dlv process to be created detached or not. there is
-        -- an issue on Windows where this needs to be set to false
-        -- otherwise the dlv server creation will fail.
-        detached = true
+        -- an issue on delve versions < 1.24.0 for Windows where this needs to be
+        -- set to false, otherwise the dlv server creation will fail.
+        detached = vim.fn.has("win32") == 0,
       },
       -- options related to running closest test
       tests = {

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -14,8 +14,8 @@ local default_config = {
     port = "${port}",
     args = {},
     build_flags = "",
-    -- Automativally handle the issue on Windows where delve needs
-    -- to be run in attched mode or it will fail (actually crashes).
+    -- Automatically handle the issue on delve Windows versions < 1.24.0
+    -- where delve needs to be run in attched mode or it will fail (actually crashes).
     detached = vim.fn.has("win32") == 0,
   },
   tests = {


### PR DESCRIPTION
The issue where delve crashes on windows if started withouth the `detached` option set to `false` was actually solved as part of this issue: https://github.com/go-delve/delve/issues/3864 and it is part of the `1.24.0` release: https://github.com/go-delve/delve/blob/master/CHANGELOG.md#1240-2024-12-18

So I updated the comments to specify that this option needs to be `false` only on versions less than `1.24.0`.