### PR TITLE
fix: debug test does not output to REPL

### DIFF
--- a/doc/nvim-dap-go.txt
+++ b/doc/nvim-dap-go.txt
@@ -129,6 +129,15 @@ To debug the closest method above the cursor use you can run:
     :lua require('dap-go').debug_test()`
 <
 
+The |dap-configuration| in use can be customized by passing an optional
+table argument to `debug-test`. For example, you can override default
+build flags as follows:
+>lua
+    require("dap-go").debug_test({
+      buildFlags = "-tags=integration",
+    })
+<
+
 Once a test runs, you can simply run it again from anywhere:
 >
     :lua require('dap-go').debug_last_test()`

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -193,7 +193,7 @@ function M.setup(opts)
   setup_go_configuration(dap, internal_global_config)
 end
 
-local function debug_test(testname, testpath, build_flags, extra_args)
+local function debug_test(testname, testpath, build_flags, extra_args, custom_config)
   local dap = load_module("dap")
 
   local config = {
@@ -204,7 +204,9 @@ local function debug_test(testname, testpath, build_flags, extra_args)
     program = testpath,
     args = { "-test.run", "^" .. testname .. "$" },
     buildFlags = build_flags,
+    outputMode = "remote",
   }
+  config = vim.tbl_deep_extend("force", config, custom_config or {})
 
   if not vim.tbl_isempty(extra_args) then
     table.move(extra_args, 1, #extra_args, #config.args + 1, config.args)
@@ -213,7 +215,7 @@ local function debug_test(testname, testpath, build_flags, extra_args)
   dap.run(config)
 end
 
-function M.debug_test()
+function M.debug_test(custom_config)
   local test = ts.closest_test()
 
   if test.name == "" or test.name == nil then
@@ -232,7 +234,7 @@ function M.debug_test()
     extra_args = { "-test.v" }
   end
 
-  debug_test(test.name, test.package, M.test_buildflags, extra_args)
+  debug_test(test.name, test.package, M.test_buildflags, extra_args, custom_config)
 
   return true
 end


### PR DESCRIPTION
Recent changes in nvim-dap behavior required setting `outputMode = "remote"` in debug configs for stdout to be visible in REPL (see https://github.com/leoluz/nvim-dap-go/issues/108 for more info). The problem is now fixed for test scenarios too.

`test_debug` now accepts a `custom_config` argument as a way for users to get around similar problems.

fix #114