### PR TITLE
feat: add more go pre-configuration

### DIFF
--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -80,7 +80,9 @@ end
 
 local function get_closest_test()
   local stop_row = vim.api.nvim_win_get_cursor(0)[1]
-  local ft = vim.api.nvim_buf_get_option(0, "filetype")
+  local ft = vim.api.nvim_get_option_value("filetype", {
+    buf = 1,
+  })
   assert(ft == "go", "can only find test in go files, not " .. ft)
   local parser = vim.treesitter.get_parser(0)
   local root = (parser:parse()[1]):root()

--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -164,12 +164,13 @@ M.closest_test = function()
 end
 
 M.get_root_dir = function()
-  local id, client = next(vim.lsp.buf_get_clients())
+  local clients = vim.lsp.get_clients({ bufnr = 0 })
+  local id, client = next(clients)
   if id == nil then
-    error({ error_msg = "lsp client not attached" })
+    error("lsp client not attached")
   end
   if not client.config.root_dir then
-    error({ error_msg = "lsp root_dir not defined" })
+    error("lsp root_dir not defined")
   end
   return client.config.root_dir
 end

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -15,7 +15,7 @@ local default_config = {
     args = {},
     build_flags = "",
     -- Automatically handle the issue on delve Windows versions < 1.24.0
-    -- where delve needs to be run in attched mode or it will fail (actually crashes).
+    -- where delve needs to be run in attached mode or it will fail (actually crashes).
     detached = vim.fn.has("win32") == 0,
     output_mode = "remote",
   },
@@ -45,7 +45,7 @@ end
 
 local function get_build_flags(config)
   return coroutine.create(function(dap_run_co)
-    local build_flags = config.build_flags
+    local build_flags = config.build_flags or ""
     vim.ui.input({ prompt = "Build Flags: " }, function(input)
       build_flags = vim.split(input or "", " ")
       coroutine.resume(dap_run_co, build_flags)
@@ -226,45 +226,7 @@ local function setup_go_configuration(dap, configs)
   local common_debug_configs = {
     {
       type = "go",
-      name = "Debug (Current File)",
-      request = "launch",
-      program = "${file}",
-      mode = "debug",
-      buildFlags = configs.delve.build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Debug (Current File & Arguments)",
-      request = "launch",
-      program = "${file}",
-      mode = "debug",
-      args = get_arguments,
-      buildFlags = configs.delve.build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Debug (Current File & Arguments & Build Flags)",
-      request = "launch",
-      program = "${file}",
-      mode = "debug",
-      args = get_arguments,
-      buildFlags = get_build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Debug (Select File)",
-      request = "launch",
-      mode = "debug",
-      program = filtered_pick_file,
-      buildFlags = configs.delve.build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Debug (Select File & Arguments)",
+      name = "dao-go: Debug (Select File & Arguments)",
       request = "launch",
       mode = "debug",
       program = filtered_pick_file,
@@ -274,45 +236,7 @@ local function setup_go_configuration(dap, configs)
     },
     {
       type = "go",
-      name = "Debug (Select File & Arguments & Build Flags)",
-      request = "launch",
-      mode = "debug",
-      program = filtered_pick_file,
-      args = get_arguments,
-      buildFlags = get_build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Debug (Select Binary)",
-      request = "launch",
-      mode = "exec",
-      program = "${command:pickFile}",
-      buildFlags = configs.delve.build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Debug (Select Binary & Arguments)",
-      request = "launch",
-      mode = "exec",
-      program = "${command:pickFile}",
-      args = get_arguments,
-      buildFlags = configs.delve.build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-
-    {
-      type = "go",
-      name = "Debug Package",
-      request = "launch",
-      program = "${fileDirname}",
-      buildFlags = configs.delve.build_flags,
-      outputMode = configs.delve.output_mode,
-    },
-    {
-      type = "go",
-      name = "Attach",
+      name = "dao-go: Attach (Pick Process)",
       mode = "local",
       request = "attach",
       processId = filtered_pick_process,
@@ -320,7 +244,7 @@ local function setup_go_configuration(dap, configs)
     },
     {
       type = "go",
-      name = "Debug test",
+      name = "dao-go: Debug Test (Current File)",
       request = "launch",
       mode = "test",
       program = "${file}",
@@ -329,7 +253,7 @@ local function setup_go_configuration(dap, configs)
     },
     {
       type = "go",
-      name = "Debug test (go.mod)",
+      name = "dao-go: Debug Test (Package)",
       request = "launch",
       mode = "test",
       program = "./${relativeFileDirname}",

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -87,7 +87,6 @@ local function setup_delve_adapter(dap, config)
   }
 
   dap.adapters.go = function(callback, client_config)
-    print(vim.inspect(client_config))
     if client_config.port == nil then
       callback(delve_config)
       return

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -54,12 +54,6 @@ end
 
 local function filtered_pick_process()
   local opts = {}
-  vim.ui.input(
-    { prompt = "Search by process name (lua pattern), or hit enter to select from the process list: " },
-    function(input)
-      opts["filter"] = input or ""
-    end
-  )
   return require("dap.utils").pick_process(opts)
 end
 

--- a/lua/dap-go.lua
+++ b/lua/dap-go.lua
@@ -57,6 +57,17 @@ local function filtered_pick_process()
   return require("dap.utils").pick_process(opts)
 end
 
+local function filtered_pick_file()
+  local opts = {
+    executables = false,
+    filter = function(path)
+      -- 检查文件扩展名是否为.go
+      return path:match("%.go$") ~= nil
+    end,
+  }
+  return require("dap.utils").pick_file(opts)
+end
+
 local function setup_delve_adapter(dap, config)
   local args = { "dap", "-l", "127.0.0.1:" .. config.delve.port }
   vim.list_extend(args, config.delve.args)
@@ -76,6 +87,7 @@ local function setup_delve_adapter(dap, config)
   }
 
   dap.adapters.go = function(callback, client_config)
+    print(vim.inspect(client_config))
     if client_config.port == nil then
       callback(delve_config)
       return
@@ -98,30 +110,82 @@ local function setup_go_configuration(dap, configs)
   local common_debug_configs = {
     {
       type = "go",
-      name = "Debug",
+      name = "Debug (Current File)",
       request = "launch",
       program = "${file}",
+      mode = "debug",
       buildFlags = configs.delve.build_flags,
       outputMode = configs.delve.output_mode,
     },
     {
       type = "go",
-      name = "Debug (Arguments)",
+      name = "Debug (Current File & Arguments)",
       request = "launch",
       program = "${file}",
+      mode = "debug",
       args = get_arguments,
       buildFlags = configs.delve.build_flags,
       outputMode = configs.delve.output_mode,
     },
     {
       type = "go",
-      name = "Debug (Arguments & Build Flags)",
+      name = "Debug (Current File & Arguments & Build Flags)",
       request = "launch",
       program = "${file}",
+      mode = "debug",
       args = get_arguments,
       buildFlags = get_build_flags,
       outputMode = configs.delve.output_mode,
     },
+    {
+      type = "go",
+      name = "Debug (Select File)",
+      request = "launch",
+      mode = "debug",
+      program = filtered_pick_file,
+      buildFlags = configs.delve.build_flags,
+      outputMode = configs.delve.output_mode,
+    },
+    {
+      type = "go",
+      name = "Debug (Select File & Arguments)",
+      request = "launch",
+      mode = "debug",
+      program = filtered_pick_file,
+      args = get_arguments,
+      buildFlags = configs.delve.build_flags,
+      outputMode = configs.delve.output_mode,
+    },
+    {
+      type = "go",
+      name = "Debug (Select File & Arguments & Build Flags)",
+      request = "launch",
+      mode = "debug",
+      program = filtered_pick_file,
+      args = get_arguments,
+      buildFlags = get_build_flags,
+      outputMode = configs.delve.output_mode,
+    },
+    {
+      type = "go",
+      name = "Debug (Select Binary)",
+      request = "launch",
+      mode = "exec",
+      program = "${command:pickFile}",
+      buildFlags = configs.delve.build_flags,
+      outputMode = configs.delve.output_mode,
+    },
+    {
+      type = "go",
+      name = "Debug (Select Binary & Arguments)",
+      request = "launch",
+      mode = "exec",
+      program = "${command:pickFile}",
+      args = get_arguments,
+      buildFlags = configs.delve.build_flags,
+      outputMode = configs.delve.output_mode,
+    },
+
     {
       type = "go",
       name = "Debug Package",


### PR DESCRIPTION
The existing config cannot meet the needs of large-scale projects

Some projects have multiple main entrances, and many microservice projects like to place main under the cmd path, such as users who use the cobra package

Now add select binary for debugging, and select main entry for debugging

feat: add config option filter_main_entrance
