### PR TITLE
Add testify support

### DIFF
--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -97,6 +97,7 @@ local testify_suite_query = [[
         (#match? @method.name "^Test.*")) @method.node
     )
   ]
+  (#eq? @method.suite.type @runner.suite.type)
 )
 ]]
 

--- a/lua/dap-go-ts.lua
+++ b/lua/dap-go-ts.lua
@@ -24,6 +24,82 @@ local subtests_query = [[
   (#eq? @run "Run")) @parent
 ]]
 
+local testify_suite_query = [[
+(source_file
+  [
+    ;; Pattern 1: Suite type before test function
+    (
+      (method_declaration
+        receiver: (parameter_list
+          (parameter_declaration
+            type: (pointer_type
+              (type_identifier) @method.suite.type)))
+        name: (field_identifier) @method.name
+        (#match? @method.name "^Test.*")) @method.node
+      
+      (function_declaration
+        name: (identifier) @test.name
+        body: (block
+          (expression_statement
+            (call_expression
+              function: (selector_expression
+                operand: (identifier) @suite.pkg
+                field: (field_identifier) @run)
+              arguments: (argument_list
+                (_)
+                [
+                  (call_expression
+                    function: (identifier) @new
+                    arguments: (argument_list
+                      (type_identifier) @runner.suite.type)
+                    (#eq? @new "new"))
+                  (unary_expression
+                    operand: (composite_literal
+                      type: (type_identifier) @runner.suite.type))
+                ])
+              (#eq? @suite.pkg "suite")
+              (#eq? @run "Run"))))
+        (#match? @test.name "^Test.*")) @test.node
+    )
+    
+    ;; Pattern 2: Test function before suite type
+    (
+      (function_declaration
+        name: (identifier) @test.name
+        body: (block
+          (expression_statement
+            (call_expression
+              function: (selector_expression
+                operand: (identifier) @suite.pkg
+                field: (field_identifier) @run)
+              arguments: (argument_list
+                (_)
+                [
+                  (call_expression
+                    function: (identifier) @new
+                    arguments: (argument_list
+                      (type_identifier) @runner.suite.type)
+                    (#eq? @new "new"))
+                  (unary_expression
+                    operand: (composite_literal
+                      type: (type_identifier) @runner.suite.type))
+                ])
+              (#eq? @suite.pkg "suite")
+              (#eq? @run "Run"))))
+        (#match? @test.name "^Test.*")) @test.node
+      
+      (method_declaration
+        receiver: (parameter_list
+          (parameter_declaration
+            type: (pointer_type
+              (type_identifier) @method.suite.type)))
+        name: (field_identifier) @method.name
+        (#match? @method.name "^Test.*")) @method.node
+    )
+  ]
+)
+]]
+
 local function format_subtest(testcase, test_tree)
   local parent
   if testcase.parent then
@@ -122,6 +198,31 @@ local function get_closest_test()
         end
       end
     end
+    table.insert(test_tree, test_match)
+  end
+
+  local testify_query = vim.treesitter.query.parse(ft, testify_suite_query)
+  assert(testify_query, "could not parse testify suite query")
+  for _, match, _ in testify_query:iter_matches(root, 0, 0, stop_row, { all = true }) do
+    local test_match = {}
+    for id, nodes in pairs(match) do
+      for _, node in ipairs(nodes) do
+        local capture = testify_query.captures[id]
+        if capture == "method.name" then
+          local name = vim.treesitter.get_node_text(node, 0)
+          test_match.name = name
+        end
+        if capture == "method.node" then
+          test_match.node = node
+        end
+        if capture == "test.name" then
+          local name = vim.treesitter.get_node_text(node, 0)
+          test_match.parent = name
+        end
+      end
+    end
+    test_match.name = test_match.parent .. "/" .. test_match.name
+    test_match.parent = nil
     table.insert(test_tree, test_match)
   end
 

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,3 +1,11 @@
 module github.com/leoluz/nvim-dap-go
 
 go 1.22.2
+
+require github.com/stretchr/testify v1.11.1
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tests/testify_test.go
+++ b/tests/testify_test.go
@@ -1,0 +1,46 @@
+package tests
+
+// Basic imports
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+// Define the suite, and absorb the built-in basic suite
+// functionality from testify - including a T() method which
+// returns the current testing context
+type ExampleTestSuite struct {
+	suite.Suite
+	VariableThatShouldStartAtFive int
+}
+
+// Make sure that VariableThatShouldStartAtFive is set to five
+// before each test
+func (suite *ExampleTestSuite) SetupTest() {
+	suite.VariableThatShouldStartAtFive = 5
+}
+
+// All methods that begin with "Test" are run as tests within a
+// suite.
+func (suite *ExampleTestSuite) TestExample() {
+	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
+	suite.Equal(5, suite.VariableThatShouldStartAtFive)
+}
+
+func (suite *ExampleTestSuite) TestExample2() {
+	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
+	suite.Equal(5, suite.VariableThatShouldStartAtFive)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestExampleTestSuite(t *testing.T) {
+	suite.Run(t, new(ExampleTestSuite))
+}
+
+func (suite *ExampleTestSuite) TestExample3() {
+	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
+	suite.Equal(5, suite.VariableThatShouldStartAtFive)
+}

--- a/tests/testify_test.go
+++ b/tests/testify_test.go
@@ -1,6 +1,5 @@
 package tests
 
-// Basic imports
 import (
 	"testing"
 
@@ -8,39 +7,27 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-// Define the suite, and absorb the built-in basic suite
-// functionality from testify - including a T() method which
-// returns the current testing context
 type ExampleTestSuite struct {
 	suite.Suite
 	VariableThatShouldStartAtFive int
 }
 
-// Make sure that VariableThatShouldStartAtFive is set to five
-// before each test
 func (suite *ExampleTestSuite) SetupTest() {
 	suite.VariableThatShouldStartAtFive = 5
 }
 
-// All methods that begin with "Test" are run as tests within a
-// suite.
+// This test should be detected
 func (suite *ExampleTestSuite) TestExample() {
 	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
 	suite.Equal(5, suite.VariableThatShouldStartAtFive)
 }
 
-func (suite *ExampleTestSuite) TestExample2() {
-	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
-	suite.Equal(5, suite.VariableThatShouldStartAtFive)
-}
-
-// In order for 'go test' to run this suite, we need to create
-// a normal test function and pass our suite to suite.Run
 func TestExampleTestSuite(t *testing.T) {
 	suite.Run(t, new(ExampleTestSuite))
 }
 
-func (suite *ExampleTestSuite) TestExample3() {
+// Also make sure that tests defined below the Test function are detected
+func (suite *ExampleTestSuite) TestExample2() {
 	assert.Equal(suite.T(), 5, suite.VariableThatShouldStartAtFive)
 	suite.Equal(5, suite.VariableThatShouldStartAtFive)
 }


### PR DESCRIPTION
This PR adds support for running tests in testify suites.
Basically each test is a method on a suite struct, and the suite is run from a regular test function.

Issues
- https://github.com/leoluz/nvim-dap-go/issues/98
- https://github.com/leoluz/nvim-dap-go/issues/113

Basically it looks for a method_declaration where the struct matches `^.*TestSuite` and a test function that has something like `suite.Run(_, [new(@struct_name), &@struct_name{}])`
Then runs the test with `"test_name/method_name"`

I also have two variants, one has the test defined before the method, the other one has the method defined before the test. I couldn't get it to match the tests after otherwise.